### PR TITLE
feat: Persistent `OpenSearch` container volume.

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -46,8 +46,8 @@ services:
       nofile:
         soft: 65536 # maximum number of open files for the OpenSearch user, set to at least 65536 on modern systems
         hard: 65536
-    # volumes:
-    #   - volume_opensearch:/usr/share/opensearch/data
+    volumes:
+      - volume_opensearch:/usr/share/opensearch/data
     ports:
       - ${OPENSEARCH_PORT}:9200
       - ${OPENSEARCH_PERFORMANCE_PORT}:9600 # required for Performance Analyzer


### PR DESCRIPTION
When restarting the open search service, the database indexes are lost, so it is necessary to export the dictionary again, which can consume time and resources unnecessarily.


![imagen](https://github.com/adempiere/opensearch_gateway_rs/assets/20288327/4a63479f-ab79-4863-8bb8-4d13a2373c4c)
