### PR TITLE
feat: Response a element with filter by identifier.

### DIFF
--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -122,7 +122,9 @@ async fn get_menu<'a>(_req: &mut Request, _res: &mut Response) {
         let _user_id = _req.queries().get("user_id");
         let _search_value = _req.queries().get("search_value");
         match menus(_language, _client_id, _role_id, _user_id, _search_value).await {
-            Ok(menu) => _res.render(Json(menu)),
+            Ok(menus_list) => {
+                _res.render(Json(menus_list));
+            },
             Err(e) => {
                 _res.render(e.to_string());
                 _res.status_code(StatusCode::INTERNAL_SERVER_ERROR);    
@@ -146,7 +148,9 @@ async fn get_process<'a>(_req: &mut Request, _res: &mut Response) {
         }
     } else {
         match processes(_language, _client_id, _role_id, _user_id, _search_value).await {
-            Ok(menu) => _res.render(Json(menu)),
+            Ok(processes_list) => {
+                _res.render(Json(processes_list));
+            },
             Err(e) => {
                 _res.render(e.to_string());
                 _res.status_code(StatusCode::INTERNAL_SERVER_ERROR);    
@@ -170,7 +174,9 @@ async fn get_browsers<'a>(_req: &mut Request, _res: &mut Response) {
         }
     } else {
         match browsers(_language, _client_id, _role_id, _user_id, _search_value).await {
-            Ok(menu) => _res.render(Json(menu)),
+            Ok(browsers_list) => {
+                _res.render(Json(browsers_list));
+            },
             Err(e) => {
                 _res.render(e.to_string());
                 _res.status_code(StatusCode::INTERNAL_SERVER_ERROR);    
@@ -194,7 +200,9 @@ async fn get_windows<'a>(_req: &mut Request, _res: &mut Response) {
         }
     } else {
         match windows(_language, _client_id, _role_id, _user_id, _search_value).await {
-            Ok(menu) => _res.render(Json(menu)),
+            Ok(windows_list) => {
+                _res.render(Json(windows_list));
+            },
             Err(e) => {
                 _res.render(e.to_string());
                 _res.status_code(StatusCode::INTERNAL_SERVER_ERROR);    

--- a/src/models/browser.rs
+++ b/src/models/browser.rs
@@ -252,19 +252,22 @@ pub struct DependendField {
     pub parent_uuid: Option<String>,
 }
 
-pub async fn browser_from_id(_language: Option<&String>, _client_id: Option<&String>, _role_id: Option<&String>, _user_id: Option<&String>, _id: Option<i32>) -> Result<BrowserResponse, String> {
+pub async fn browser_from_id(_language: Option<&String>, _client_id: Option<&String>, _role_id: Option<&String>, _user_id: Option<&String>, _id: Option<i32>) -> Result<Browser, String> {
     let mut _document = Browser::from_id(_id);
     let _index_name = get_index_name(_language, _client_id, _role_id, _user_id).await.expect("Error getting index");
     log::info!("Index to search {:}", _index_name);
     _document.index_value = Some(_index_name);
-    let _menu_document: &dyn IndexDocument = &_document;
-    match get_by_id(_menu_document).await {
+    let _browser_document: &dyn IndexDocument = &_document;
+    match get_by_id(_browser_document).await {
         Ok(value) => {
             let browser: Browser = serde_json::from_value(value).unwrap();
             log::info!("Finded Value: {:?}", browser.id);
-            Ok(BrowserResponse {
-                browser: Some(browser)
-            })
+            // Ok(BrowserResponse {
+            //     browser: Some(browser)
+            // })
+            Ok( 
+                browser
+            )
         },
         Err(error) => {
             log::warn!("{}", error);
@@ -326,16 +329,16 @@ pub async fn browsers(_language: Option<&String>, _client_id: Option<&String>, _
     log::info!("Index to search {:}", _index_name);
     let mut _document = Browser::default();
     _document.index_value = Some(_index_name);
-    let _menu_document: &dyn IndexDocument = &_document;
-    match find(_menu_document, _search_value, 0, 10).await {
+    let _browser_document: &dyn IndexDocument = &_document;
+    match find(_browser_document, _search_value, 0, 10).await {
         Ok(values) => {
-            let mut menus: Vec<Browser> = vec![];
+            let mut browsers_list: Vec<Browser> = vec![];
             for value in values {
-                let menu: Browser = serde_json::from_value(value).unwrap();
-                menus.push(menu.to_owned());
+                let browser: Browser = serde_json::from_value(value).unwrap();
+                browsers_list.push(browser.to_owned());
             }
             Ok(BrowserListResponse {
-                browsers: Some(menus)
+                browsers: Some(browsers_list)
             })
         },
         Err(error) => Err(Error::new(ErrorKind::InvalidData.into(), error))

--- a/src/models/menu.rs
+++ b/src/models/menu.rs
@@ -181,16 +181,19 @@ pub struct Workflow {
     pub help: Option<String>,
 }
 
-pub async fn menu_from_id(_id: Option<i32>) -> Result<MenuResponse, String> {
+pub async fn menu_from_id(_id: Option<i32>) -> Result<Menu, String> {
     let mut _document = Menu::from_id(_id);
     let _menu_document: &dyn IndexDocument = &_document;
     match get_by_id(_menu_document).await {
         Ok(value) => {
             let menu: Menu = serde_json::from_value(value).unwrap();
             log::info!("Finded Value: {:?}", menu.id);
-            Ok(MenuResponse {
-                menu: Some(menu)
-            })
+            // Ok(MenuResponse {
+            //     menu: Some(menu)
+            // })
+            Ok(
+                menu
+            )
         },
         Err(error) => {
             log::warn!("{}", error);
@@ -251,13 +254,13 @@ pub async fn menus(_language: Option<&String>, _client_id: Option<&String>, _rol
     let _menu_document: &dyn IndexDocument = &_document;
     match find(_menu_document, _search_value, 0, 10).await {
         Ok(values) => {
-            let mut menus: Vec<Menu> = vec![];
+            let mut menus_list: Vec<Menu> = vec![];
             for value in values {
                 let menu: Menu = serde_json::from_value(value).unwrap();
-                menus.push(menu.to_owned());
+                menus_list.push(menu.to_owned());
             }
             Ok(MenuListResponse {
-                menus: Some(menus)
+                menus: Some(menus_list)
             })
         },
         Err(error) => Err(Error::new(ErrorKind::InvalidData.into(), error))

--- a/src/models/process.rs
+++ b/src/models/process.rs
@@ -23,8 +23,8 @@ pub struct ProcessListResponse {
 
 impl Default for ProcessResponse {
     fn default() -> Self {
-        ProcessResponse { 
-            process: None 
+        ProcessResponse {
+            process: None
         }
     }
 }
@@ -223,7 +223,7 @@ pub struct Workflow {
     pub help: Option<String>,
 }
 
-pub async fn process_from_id(_language: Option<&String>, _client_id: Option<&String>, _role_id: Option<&String>, _user_id: Option<&String>, _id: Option<i32>) -> Result<ProcessResponse, String> {
+pub async fn process_from_id(_language: Option<&String>, _client_id: Option<&String>, _role_id: Option<&String>, _user_id: Option<&String>, _id: Option<i32>) -> Result<Process, String> {
     let mut _document = Process::from_id(_id);
     let _index_name = get_index_name(_language, _client_id, _role_id, _user_id).await.expect("Error getting index");
     log::info!("Index to search {:}", _index_name);
@@ -233,9 +233,12 @@ pub async fn process_from_id(_language: Option<&String>, _client_id: Option<&Str
         Ok(value) => {
             let process: Process = serde_json::from_value(value).unwrap();
             log::info!("Finded Value: {:?}", process.id);
-            Ok(ProcessResponse {
-                process: Some(process)
-            })
+            // Ok(ProcessResponse {
+            //     process: Some(process)
+            // })
+            Ok(
+                process
+            )
         },
         Err(error) => {
             log::warn!("{}", error);
@@ -297,16 +300,16 @@ pub async fn processes(_language: Option<&String>, _client_id: Option<&String>, 
     log::info!("Index to search {:}", _index_name);
     let mut _document = Process::default();
     _document.index_value = Some(_index_name);
-    let _menu_document: &dyn IndexDocument = &_document;
-    match find(_menu_document, _search_value, 0, 10).await {
+    let _process_document: &dyn IndexDocument = &_document;
+    match find(_process_document, _search_value, 0, 10).await {
         Ok(values) => {
-            let mut menus: Vec<Process> = vec![];
+            let mut processes_list: Vec<Process> = vec![];
             for value in values {
-                let menu: Process = serde_json::from_value(value).unwrap();
-                menus.push(menu.to_owned());
+                let process: Process = serde_json::from_value(value).unwrap();
+                processes_list.push(process.to_owned());
             }
             Ok(ProcessListResponse {
-                processes: Some(menus)
+                processes: Some(processes_list)
             })
         },
         Err(error) => Err(Error::new(ErrorKind::InvalidData.into(), error))

--- a/src/models/window.rs
+++ b/src/models/window.rs
@@ -261,19 +261,20 @@ pub struct Table {
     pub selection_colums: Option<Vec<String>>,
 }
 
-pub async fn window_from_id(_language: Option<&String>, _client_id: Option<&String>, _role_id: Option<&String>, _user_id: Option<&String>, _id: Option<i32>) -> Result<WindowResponse, String> {
+pub async fn window_from_id(_language: Option<&String>, _client_id: Option<&String>, _role_id: Option<&String>, _user_id: Option<&String>, _id: Option<i32>) -> Result<Window, String> {
     let mut _document = Window::from_id(_id);
     let _index_name = get_index_name(_language, _client_id, _role_id, _user_id).await.expect("Error getting index");
     log::info!("Index to search {:}", _index_name);
     _document.index_value = Some(_index_name);
-    let _menu_document: &dyn IndexDocument = &_document;
-    match get_by_id(_menu_document).await {
+    let _window_document: &dyn IndexDocument = &_document;
+    match get_by_id(_window_document).await {
         Ok(value) => {
             let window: Window = serde_json::from_value(value).unwrap();
             log::info!("Finded Value: {:?}", window.id);
-            Ok(WindowResponse {
-                window: Some(window)
-            })
+            // Ok(WindowResponse {
+            //     window: Some(window)
+            // })
+            Ok(window)
         },
         Err(error) => {
             log::warn!("{}", error);
@@ -336,16 +337,16 @@ pub async fn windows(_language: Option<&String>, _client_id: Option<&String>, _r
     log::info!("Index to search {:}", _index_name);
     let mut _document = Window::default();
     _document.index_value = Some(_index_name);
-    let _menu_document: &dyn IndexDocument = &_document;
-    match find(_menu_document, _search_value, 0, 10).await {
+    let _window_document: &dyn IndexDocument = &_document;
+    match find(_window_document, _search_value, 0, 10).await {
         Ok(values) => {
-            let mut menus: Vec<Window> = vec![];
+            let mut windows_list: Vec<Window> = vec![];
             for value in values {
-                let menu: Window = serde_json::from_value(value).unwrap();
-                menus.push(menu.to_owned());
+                let window: Window = serde_json::from_value(value).unwrap();
+                windows_list.push(window.to_owned());
             }
             Ok(WindowListResponse {
-                windows: Some(menus)
+                windows: Some(windows_list)
             })
         },
         Err(error) => Err(Error::new(ErrorKind::InvalidData.into(), error))


### PR DESCRIPTION
Currently when filtering by identifier (which like the uuid is unique) it replaces the structure within a hierarchy, instead of response values directly in the root of the json.


### Before this changes

```json
{
    "browser": {
        "uuid": "8aaf0086-fb40-11e8-a479-7a0060f0aa01",
        "id": 50018,
        "code": "Activities Progress Monitor",
        "name": "Monitor de Progreso de Actividades",
        "description": "Monitor de Progreso de Actividades",
        "help": null,
        "is_execute_query_by_default": false,
        "is_collapsible_by_default": false,
        "is_selected_by_default": false,
        "is_show_total": false,
        "field_key": "OA_PP_Order_Node_ID",
        "access_level": "3",
        "is_updateable": false,
        "is_deleteable": false,
        "table_name": null,
        "table": null,
        "index_value": "browser_es_mx_11",
        "language": "es_MX",
        "client_id": 11,
        "role_id": null,
        "user_id": null,
        "context_column_names": [],
        "process_id": 0,
        "process": null,
        "window_id": 53009,
        "window": {
            "id": 53009,
            "uuid": "a521e6f4-fb40-11e8-a479-7a0060f0aa01",
            "name": "Orden de Manufactura",
            "description": "Mantenimiento de órdenes de manufactura",
            "help": "Manufacturing Schedule is a document group of documents or schedule identity  conveying authority for the manufacture of specified parts or products in specified quantities."
        },
        "display_fields": [],
        "criteria_fields": [],
        "identifier_fields": [],
        "order_fields": [],
        "editable_fields": []
    }
}
```



### After this changes

```json
{
    "uuid": "8aaf0086-fb40-11e8-a479-7a0060f0aa01",
    "id": 50018,
    "code": "Activities Progress Monitor",
    "name": "Monitor de Progreso de Actividades",
    "description": "Monitor de Progreso de Actividades",
    "help": null,
    "is_execute_query_by_default": false,
    "is_collapsible_by_default": false,
    "is_selected_by_default": false,
    "is_show_total": false,
    "field_key": "OA_PP_Order_Node_ID",
    "access_level": "3",
    "is_updateable": false,
    "is_deleteable": false,
    "table_name": null,
    "table": null,
    "index_value": "browser_es_mx_11",
    "language": "es_MX",
    "client_id": 11,
    "role_id": null,
    "user_id": null,
    "context_column_names": [],
    "process_id": 0,
    "process": null,
    "window_id": 53009,
    "window": {
        "id": 53009,
        "uuid": "a521e6f4-fb40-11e8-a479-7a0060f0aa01",
        "name": "Orden de Manufactura",
        "description": "Mantenimiento de órdenes de manufactura",
        "help": "Manufacturing Schedule is a document group of documents or schedule identity  conveying authority for the manufacture of specified parts or products in specified quantities."
    },
    "display_fields": [],
    "criteria_fields": [],
    "identifier_fields": [],
    "order_fields": [],
    "editable_fields": []
}
```