### PR TITLE
feat: Add `menu process browser window` to kafka default topics.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ docker run -d -p 7878:7878 --name opensearch-gateway-rs -e KAFKA_ENABLED="N" -e 
 #### Environment variables
 - `HOST`: Internal host for container. Default: `0.0.0.0:7878`
 - `KAFKA_ENABLED`: Define if the kafka consumer is enabled. Default: `N`
-- `KAFKA_QUEUES`: Apply for `KAFKA_ENABLED` flag, this can subscribe to many topics using space between topic. Default: `menu`
+- `KAFKA_QUEUES`: Apply for `KAFKA_ENABLED` flag, this can subscribe to many topics using space between topic. Default: `menu process browser window`
 - `KAFKA_HOST`: Kafka cluster and port for connect. Default: `0.0.0.0:29092`
 - `KAFKA_GROUP`: Kafka group for subscription. Default: `default`
 - `OPENSEARCH_URL`: Open Search service host and port. Default `http://localhost:9200`

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -226,15 +226,17 @@ async fn consume_queue() {
             "default".to_owned()
         }.to_owned(),
     };
-    let kafka_queues =  match env::var("KAFKA_QUEUES") {
+	let kafka_queues: String = match env::var("KAFKA_QUEUES") {
         Ok(value) => value.clone(),
         Err(_) => {
             log::info!("Variable `KAFKA_QUEUES` Not found from enviroment, loaded with `default` value");
-            "ad_menu".to_owned()
-        }.to_owned(),
+			"menu process browser window".to_owned()
+		}.to_owned()
     };
-    
+
     let topics: Vec<&str> = kafka_queues.split_whitespace().collect();
+	log::info!("Topics to Subscribed: {:?}", topics.to_owned());
+
     let consumer = create_consumer(&kafka_host, &kafka_group, &topics);
     loop {
         match consumer.recv().await {


### PR DESCRIPTION
if no value is specified in the `KAFKA_QUEUES` environment variable it used to take the value `ad_menu` however it is not a valid topic, instead it now takes `menu process browser window`.

![imagen](https://github.com/adempiere/opensearch_gateway_rs/assets/20288327/4f622728-aeed-4160-a599-71f5936af4a2)

