### PR TITLE
feat: Add `action_id` and `action_uuid` on Menu structure.

### DIFF
--- a/src/models/menu.rs
+++ b/src/models/menu.rs
@@ -40,17 +40,21 @@ pub struct Menu {
     pub is_summary: Option<bool>,
     pub is_sales_transaction: Option<bool>,
     pub is_read_only: Option<bool>,
-    pub action: Option<String>,
+    // index
     pub index_value: Option<String>,
     pub language: Option<String>,
     pub client_id: Option<i32>,
     pub role_id: Option<i32>,
     pub user_id: Option<i32>,
+    // Supported References
+    pub action: Option<String>,
+    pub action_id: Option<i32>,
     pub window: Option<Window>,
     pub process: Option<Process>,
     pub form: Option<Form>,
     pub browse: Option<Browse>,
     pub workflow: Option<Workflow>,
+    // Tree menu childs
     pub children: Option<Vec<Menu>>
 }
 
@@ -66,7 +70,8 @@ impl Default for Menu {
             is_summary: None, 
             is_sales_transaction: None, 
             is_read_only: None, 
-            action: None, 
+            action: None,
+            action_id: None,
             window: None, 
             process: None, 
             form: None, 

--- a/src/models/menu.rs
+++ b/src/models/menu.rs
@@ -49,6 +49,7 @@ pub struct Menu {
     // Supported References
     pub action: Option<String>,
     pub action_id: Option<i32>,
+    pub action_uuid: Option<String>,
     pub window: Option<Window>,
     pub process: Option<Process>,
     pub form: Option<Form>,
@@ -70,19 +71,23 @@ impl Default for Menu {
             is_summary: None, 
             is_sales_transaction: None, 
             is_read_only: None, 
+			// index
+			index_value: None,
+			language: None,
+			client_id: None,
+			role_id: None,
+			user_id: None,
+			// Supported References
             action: None,
-            action_id: None,
+			action_id: None,
+			action_uuid: None,
             window: None, 
             process: None, 
             form: None, 
             browse: None,
-            children: None,
-            client_id: None,
-            index_value: None,
-            language: None,
-            role_id: None,
-            user_id: None,
-            workflow: None
+			workflow: None,
+			// Tree menu childs
+			children: None
         }
     }
 }


### PR DESCRIPTION
To prevent the frontend from constructing the `action_id` (as `reference_id`) or `action_uuid` (as `reference_uuid`) by searching inside process, smart browse, window, workflow or form, the attribute is rounded by placing it at the root of the structure.


![imagen](https://github.com/adempiere/adempiere-kafka-connector/assets/20288327/6cf5d3e1-0329-4882-82d1-dd7c3bb8d641)

fixes https://github.com/solop-develop/frontend-core/issues/1994
