### PR TITLE
feat: Update `GitHub` actions.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build
       run: cargo build --verbose
     - name: Run tests
@@ -31,7 +31,7 @@ jobs:
           cp target/debug/server distributions/
 
     - name: Upload Binary Files
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
           name: dictionary_rs
           path: distributions/

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,20 +42,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           # CONFIGURE DOCKER SECRETS INTO REPOSITORY
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Push image in Docker Hub
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: docker/Dockerfile

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.77.1-bullseye as builder
+FROM rust:1.78.0-bullseye as builder
 
 LABEL maintainer="ysenih@erpya.com; EdwinBetanc0urt@outlook.com;" \
 	description="A Image for start service from rust binary"
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y pkg-config libssl-dev && rm -rf /var/li
     cargo install --config net.git-fetch-with-cli=true --path . && \
     mv docker/.env /usr/local/cargo/bin/
 
-FROM debian:bullseye
+FROM debian:bullseye-20240423
 
 ENV \
     RUST_LOG="info" \


### PR DESCRIPTION
GitHub actions update:
- `actions/checkout` from `v3` to `v4`.
- `actions/upload-artifact` from `v3` to `v4`.
- `docker/setup-qemu-action` from `v2` to `v3`.
- `docker/setup-buildx-action` from `v2` to `v3`.
- `docker/login-action` from `v2` to `v3`.
- `docker/build-push-action` from `v4` to `v5`.

Docker images update:
- `rust:1.77.1-bullseye` to `rust:1.78.0-bullseye`.
- `debian:bullseye` to `debian:bullseye-20240423`.


