### PR TITLE
fix: `KAFKA_QUEUES` env on docker image.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@ ENV \
     RUST_LOG="info" \
 	PORT="7878" \
     KAFKA_ENABLED="Y" \
-    KAFKA_QUEUES="menu process browser window" \
+	KAFKA_QUEUES="menu form browser process window" \
     ALLOWED_ORIGIN="*" \
     KAFKA_HOST="0.0.0.0:9092" \
     KAFKA_GROUP="default" \


### PR DESCRIPTION
fixes https://github.com/solop-develop/frontend-core/issues/2200