### PR TITLE
fix: Get documents with base values.

### DIFF
--- a/src/models/browser.rs
+++ b/src/models/browser.rs
@@ -301,28 +301,44 @@ async fn get_index_name(_language: Option<&String>, _client_id: Option<&String>,
     if _role_id.is_none() {
         return Err(Error::new(ErrorKind::InvalidData.into(), "Role is Mandatory"));
     }
-    let _index = "browser".to_string();
-    let _user_index = match _user_id {
-        Some(_) => user_index(_index.to_owned(), _language, _client_id, _role_id, _user_id),
-        None => role_index(_index.to_owned(), _language, _client_id, _role_id)
-    };
+
+	let _index: String = "browser".to_string();
+
+	let _user_index = user_index(_index.to_owned(), _language, _client_id, _role_id, _user_id);
     let _role_index = role_index(_index.to_owned(), _language, _client_id, _role_id);
-    let _client_index = client_index(_index.to_owned(), _language, _client_id, _role_id);
-    let _language_index = language_index(_index.to_owned(), _language, _client_id, _role_id);
-    let _default_index = default_index(_index.to_owned(), _language, _client_id, _role_id);
-    //  Find index
+	let _client_index = client_index(_index.to_owned(), _language, _client_id);
+	let _language_index = language_index(_index.to_owned(), _language);
+	let _default_index = default_index(_index.to_owned());
+
+	//  Find index
     match exists_index(_user_index.to_owned()).await {
-        Ok(_) => Ok(_user_index),
+		Ok(_) => {
+			log::info!("Find with user index `{:}`", _user_index);
+			Ok(_user_index)
+		},
         Err(_) => {
+			log::info!("No user index `{:}`", _user_index);
             match exists_index(_role_index.to_owned()).await {
-                Ok(_) => Ok(_role_index),
+                Ok(_) => {
+					log::info!("Find with role index `{:}`", _role_index);
+					Ok(_role_index)
+				},
                 Err(_) => {
+					log::info!("No role index `{:}`", _role_index);
                     match exists_index(_client_index.to_owned()).await {
-                        Ok(_) => Ok(_client_index),
+                        Ok(_) => {
+							log::info!("Find with client index `{:}`", _client_index);
+							Ok(_client_index)
+						},
                         Err(_) => {
-                            match exists_index(_language_index.to_owned()).await {
-                                Ok(_) => Ok(_language_index),
+							log::info!("No client index `{:}`", _client_index);
+							match exists_index(_language_index.to_owned()).await {
+								Ok(_) => {
+									log::info!("Find with language index `{:}`", _language_index);
+									Ok(_language_index)
+								},
                                 Err(_) => {
+									log::info!("No language index `{:}`. Find with default index `{:}`.", _language_index, _default_index);
                                     Ok(_default_index)
                                 }
                             }
@@ -339,8 +355,10 @@ pub async fn browsers(_language: Option<&String>, _client_id: Option<&String>, _
         Some(value) => value.clone(),
         None => "".to_owned()
     };
+
     let _index_name = get_index_name(_language, _client_id, _role_id, _user_id).await.expect("Error getting index");
     log::info!("Index to search {:}", _index_name);
+
     let mut _document = Browser::default();
     _document.index_value = Some(_index_name);
     let _browser_document: &dyn IndexDocument = &_document;

--- a/src/models/menu.rs
+++ b/src/models/menu.rs
@@ -212,68 +212,78 @@ pub async fn menu_from_id(_id: Option<i32>) -> Result<Menu, String> {
     }
 }
 
+async fn get_index_name(_language: Option<&String>, _client_id: Option<&String>, _role_id: Option<&String>, _user_id: Option<&String>) -> Result<String, std::io::Error> {
+	//  Validate
+	if _language.is_none() {
+		return Err(Error::new(ErrorKind::InvalidData.into(), "Language is Mandatory"));
+	}
+	if _client_id.is_none() {
+		return Err(Error::new(ErrorKind::InvalidData.into(), "Client is Mandatory"));
+	}
+	if _role_id.is_none() {
+		return Err(Error::new(ErrorKind::InvalidData.into(), "Role is Mandatory"));
+	}
+
+	let _index: String = "menu".to_string();
+
+	let _user_index = user_index(_index.to_owned(), _language, _client_id, _role_id, _user_id);
+    let _role_index = role_index(_index.to_owned(), _language, _client_id, _role_id);
+	let _client_index = client_index(_index.to_owned(), _language, _client_id);
+	let _language_index = language_index(_index.to_owned(), _language);
+	let _default_index = default_index(_index.to_owned());
+
+	//  Find index
+	match exists_index(_user_index.to_owned()).await {
+		Ok(_) => {
+			log::info!("Find with user index `{:}`", _user_index);
+			Ok(_user_index)
+		},
+		Err(_) => {
+			log::info!("No user index `{:}`", _user_index);
+			match exists_index(_role_index.to_owned()).await {
+				Ok(_) => {
+					log::info!("Find with role index `{:}`", _role_index);
+					Ok(_role_index)
+				},
+				Err(_) => {
+					log::info!("No role index `{:}`", _role_index);
+					match exists_index(_client_index.to_owned()).await {
+						Ok(_) => {
+							log::info!("Find with client index `{:}`", _client_index);
+							Ok(_client_index)
+						},
+						Err(_) => {
+							log::info!("No client index `{:}`", _client_index);
+							match exists_index(_language_index.to_owned()).await {
+								Ok(_) => {
+									log::info!("Find with language index `{:}`", _language_index);
+									Ok(_language_index)
+								},
+								Err(_) => {
+									log::info!("No language index `{:}`. Find with default index `{:}`.", _language_index, _default_index);
+									Ok(_default_index)
+								}
+							}
+						}
+					}
+				}
+            }
+		}
+	}
+}
+
 pub async fn menus(
 	_language: Option<&String>, _client_id: Option<&String>, _role_id: Option<&String>, _user_id: Option<&String>,
 	_search_value: Option<&String>, _page_number: Option<&String>, _page_size: Option<&String>
 ) -> Result<MenuListResponse, std::io::Error> {
-    //  Validate
-    if _language.is_none() {
-        return Err(Error::new(ErrorKind::InvalidData.into(), "Language is Mandatory"));
-    }
-    if _client_id.is_none() {
-        return Err(Error::new(ErrorKind::InvalidData.into(), "Client is Mandatory"));
-    }
-    if _role_id.is_none() {
-        return Err(Error::new(ErrorKind::InvalidData.into(), "Role is Mandatory"));
-    }
-    let _search_value = match _search_value {
-        Some(value) => value.clone(),
-        None => "".to_owned()
-    };
-    let _index = "menu".to_string();
-    let _user_index = match _user_id {
-        Some(_) => user_index(_index.to_owned(), _language, _client_id, _role_id, _user_id),
-        None => role_index(_index.to_owned(), _language, _client_id, _role_id)
-    };
-    let _role_index = role_index(_index.to_owned(), _language, _client_id, _role_id);
-    let _client_index = client_index(_index.to_owned(), _language, _client_id, _role_id);
-    let _language_index = language_index(_index.to_owned(), _language, _client_id, _role_id);
-    let _default_index = default_index(_index.to_owned(), _language, _client_id, _role_id);
-    //  Find index
-    let _index_name = match exists_index(_user_index.to_owned()).await {
-		Ok(_) => {
-			log::info!("Find with user index {:}", _user_index);
-			_user_index
-		},
-        Err(_) => {
-            match exists_index(_role_index.to_owned()).await {
-				Ok(_) => {
-					log::info!("Find with role index {:}", _role_index);
-					_role_index
-                },
-                Err(_) => {
-                    match exists_index(_client_index.to_owned()).await {
-						Ok(_) => {
-							log::info!("Find with client index {:}", _client_index);
-							_client_index
-						},
-                        Err(_) => {
-                            match exists_index(_language_index.to_owned()).await {
-								Ok(_) => {
-									log::info!("Find with language index {:}", _language_index);
-									_language_index
-								},
-                                Err(_) => {
-                                    _default_index
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    };
+	let _search_value = match _search_value {
+		Some(value) => value.clone(),
+		None => "".to_owned()
+	};
+
+	let _index_name = get_index_name(_language, _client_id, _role_id, _user_id).await.expect("Error getting index");
     log::info!("Index to search {:}", _index_name);
+
     let mut _document = Menu::default();
     _document.index_value = Some(_index_name);
     let _menu_document: &dyn IndexDocument = &_document;

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -17,35 +17,57 @@ pub struct Metadata {
     pub user_id: Option<i32>,
 }
 
-fn default_index(_index_name: String, _language: Option<&String>, _client_id: Option<&String>, _role_id: Option<&String>) -> String {
+fn default_index(_index_name: String) -> String {
 	let mut _index_to_find: String = _index_name.to_owned();
 	_index_to_find.to_lowercase()
 }
 
-fn language_index(_index_name: String, _language: Option<&String>, _client_id: Option<&String>, _role_id: Option<&String>) -> String {
-	let mut _index_to_find: String = default_index(_index_name, _language, _client_id, _role_id);
-	_index_to_find.push_str("_");
-	_index_to_find.push_str(_language.unwrap());
+fn language_index(_index_name: String, _language: Option<&String>) -> String {
+	let mut _index_to_find: String = default_index(_index_name);
+	if let Some(language) = _language {
+		if language != "en_US" {
+			_index_to_find.push_str("_");
+			_index_to_find.push_str(language);
+		}
+	}
 	_index_to_find.to_lowercase()
 }
 
-fn client_index(_index_name: String, _language: Option<&String>, _client_id: Option<&String>, _role_id: Option<&String>) -> String {
-	let mut _index_to_find: String = language_index(_index_name, _language, _client_id, _role_id);
-	_index_to_find.push_str("_");
-	_index_to_find.push_str(_client_id.unwrap());
+fn client_index(_index_name: String, _language: Option<&String>, _client_id: Option<&String>) -> String {
+	let mut _index_to_find: String = language_index(_index_name, _language);
+	if let Some(client_id) = _client_id {
+		if let Ok(id) = client_id.parse::<i32>() {
+			if id > 0 {
+				_index_to_find.push_str("_");
+				_index_to_find.push_str(client_id);
+			}
+		}
+	}
 	_index_to_find.to_lowercase()
 }
 
 fn role_index(_index_name: String, _language: Option<&String>, _client_id: Option<&String>, _role_id: Option<&String>) -> String {
-	let mut _index_to_find: String = client_index(_index_name, _language, _client_id, _role_id);
-	_index_to_find.push_str("_");
-	_index_to_find.push_str(_role_id.unwrap());
+	let mut _index_to_find: String = client_index(_index_name, _language, _client_id);
+	if let Some(role_id) = _role_id {
+		if let Ok(id) = role_id.parse::<i32>() {
+			if id > 0 {
+				_index_to_find.push_str("_");
+				_index_to_find.push_str(role_id);
+			}
+		}
+	}
 	_index_to_find.to_lowercase()
 }
 
 fn user_index(_index_name: String, _language: Option<&String>, _client_id: Option<&String>, _role_id: Option<&String>, _user_id: Option<&String>) -> String {
 	let mut _index_to_find: String = role_index(_index_name, _language, _client_id, _role_id);
-	_index_to_find.push_str("_");
-	_index_to_find.push_str(_user_id.unwrap());
+	if let Some(user_id) = _user_id {
+		if let Ok(id) = user_id.parse::<i32>() {
+			if id > 0 {
+				_index_to_find.push_str("_");
+				_index_to_find.push_str(user_id);
+			}
+		}
+	}
 	_index_to_find.to_lowercase()
 }

--- a/src/models/process.rs
+++ b/src/models/process.rs
@@ -269,28 +269,44 @@ async fn get_index_name(_language: Option<&String>, _client_id: Option<&String>,
     if _role_id.is_none() {
         return Err(Error::new(ErrorKind::InvalidData.into(), "Role is Mandatory"));
     }
-    let _index = "process".to_string();
-    let _user_index = match _user_id {
-        Some(_) => user_index(_index.to_owned(), _language, _client_id, _role_id, _user_id),
-        None => role_index(_index.to_owned(), _language, _client_id, _role_id)
-    };
+
+	let _index: String = "process".to_string();
+
+	let _user_index = user_index(_index.to_owned(), _language, _client_id, _role_id, _user_id);
     let _role_index = role_index(_index.to_owned(), _language, _client_id, _role_id);
-    let _client_index = client_index(_index.to_owned(), _language, _client_id, _role_id);
-    let _language_index = language_index(_index.to_owned(), _language, _client_id, _role_id);
-    let _default_index = default_index(_index.to_owned(), _language, _client_id, _role_id);
+	let _client_index = client_index(_index.to_owned(), _language, _client_id);
+	let _language_index = language_index(_index.to_owned(), _language);
+	let _default_index = default_index(_index.to_owned());
+
     //  Find index
     match exists_index(_user_index.to_owned()).await {
-        Ok(_) => Ok(_user_index),
+		Ok(_) => {
+			log::info!("Find with user index `{:}`", _user_index);
+			Ok(_user_index)
+		},
         Err(_) => {
+			log::info!("No user index `{:}`", _user_index);
             match exists_index(_role_index.to_owned()).await {
-                Ok(_) => Ok(_role_index),
+                Ok(_) => {
+					log::info!("Find with role index `{:}`", _role_index);
+					Ok(_role_index)
+				},
                 Err(_) => {
+					log::info!("No role index `{:}`", _role_index);
                     match exists_index(_client_index.to_owned()).await {
-                        Ok(_) => Ok(_client_index),
+                        Ok(_) => {
+							log::info!("Find with client index `{:}`", _client_index);
+							Ok(_client_index)
+						},
                         Err(_) => {
-                            match exists_index(_language_index.to_owned()).await {
-                                Ok(_) => Ok(_language_index),
+							log::info!("No client index `{:}`", _client_index);
+							match exists_index(_language_index.to_owned()).await {
+								Ok(_) => {
+									log::info!("Find with language index `{:}`", _language_index);
+									Ok(_language_index)
+								},
                                 Err(_) => {
+									log::info!("No language index `{:}`. Find with default index `{:}`.", _language_index, _default_index);
                                     Ok(_default_index)
                                 }
                             }
@@ -307,8 +323,10 @@ pub async fn processes(_language: Option<&String>, _client_id: Option<&String>, 
         Some(value) => value.clone(),
         None => "".to_owned()
     };
+
     let _index_name = get_index_name(_language, _client_id, _role_id, _user_id).await.expect("Error getting index");
     log::info!("Index to search {:}", _index_name);
+
     let mut _document = Process::default();
     _document.index_value = Some(_index_name);
     let _process_document: &dyn IndexDocument = &_document;

--- a/src/models/window.rs
+++ b/src/models/window.rs
@@ -309,28 +309,44 @@ async fn get_index_name(_language: Option<&String>, _client_id: Option<&String>,
     if _role_id.is_none() {
         return Err(Error::new(ErrorKind::InvalidData.into(), "Role is Mandatory"));
     }
-    let _index = "window".to_string();
-    let _user_index = match _user_id {
-        Some(_) => user_index(_index.to_owned(), _language, _client_id, _role_id, _user_id),
-        None => role_index(_index.to_owned(), _language, _client_id, _role_id)
-    };
+
+	let _index: String = "window".to_string();
+
+	let _user_index = user_index(_index.to_owned(), _language, _client_id, _role_id, _user_id);
     let _role_index = role_index(_index.to_owned(), _language, _client_id, _role_id);
-    let _client_index = client_index(_index.to_owned(), _language, _client_id, _role_id);
-    let _language_index = language_index(_index.to_owned(), _language, _client_id, _role_id);
-    let _default_index = default_index(_index.to_owned(), _language, _client_id, _role_id);
+	let _client_index = client_index(_index.to_owned(), _language, _client_id);
+	let _language_index = language_index(_index.to_owned(), _language);
+	let _default_index = default_index(_index.to_owned());
+
     //  Find index
     match exists_index(_user_index.to_owned()).await {
-        Ok(_) => Ok(_user_index),
+		Ok(_) => {
+			log::info!("Find with user index `{:}`", _user_index);
+			Ok(_user_index)
+		},
         Err(_) => {
+			log::info!("No user index `{:}`", _user_index);
             match exists_index(_role_index.to_owned()).await {
-                Ok(_) => Ok(_role_index),
+                Ok(_) => {
+					log::info!("Find with role index `{:}`", _role_index);
+					Ok(_role_index)
+				},
                 Err(_) => {
+					log::info!("No role index `{:}`", _role_index);
                     match exists_index(_client_index.to_owned()).await {
-                        Ok(_) => Ok(_client_index),
+                        Ok(_) => {
+							log::info!("Find with client index `{:}`", _client_index);
+							Ok(_client_index)
+						},
                         Err(_) => {
-                            match exists_index(_language_index.to_owned()).await {
-                                Ok(_) => Ok(_language_index),
+							log::info!("No client index `{:}`", _client_index);
+							match exists_index(_language_index.to_owned()).await {
+								Ok(_) => {
+									log::info!("Find with language index `{:}`", _language_index);
+									Ok(_language_index)
+								},
                                 Err(_) => {
+									log::info!("No language index `{:}`. Find with default index `{:}`.", _language_index, _default_index);
                                     Ok(_default_index)
                                 }
                             }


### PR DESCRIPTION
When exporting and taking the ids of the company, role and user, kafka connector as the name of the document index, for example `menu_11_101` which would be the company 11 `Garden World` and the role `Garden World Admin`, but omits them in the name of the index if it is zero, the same happens with the English language `en_US` so an index as `menu_en_us_0_0_0` remains as `menu`.

However when searching the document these values are considered in the index name `menu_en_us_11_101`, but it does not exist so it takes the default index `menu` with the company 0=System and the role 0=SuperUser.

#### Before this changes
![imagen](https://github.com/adempiere/dictionary_rs/assets/20288327/e2673662-1ee1-4e61-8f68-d8a33ad51ee3)


#### After this changes
![imagen](https://github.com/adempiere/dictionary_rs/assets/20288327/b57e87e7-967d-4ff3-bb13-4d0f4331d20f)


#### Additonal context
fixes https://github.com/solop-develop/frontend-core/issues/2272