### PR TITLE
fix: Error with mandatory query response as json.

### DIFF
--- a/src/models/browser.rs
+++ b/src/models/browser.rs
@@ -266,10 +266,21 @@ pub struct DependendField {
     pub parent_name: Option<String>
 }
 
-pub async fn browser_from_id(_language: Option<&String>, _client_id: Option<&String>, _role_id: Option<&String>, _user_id: Option<&String>, _id: Option<i32>) -> Result<Browser, String> {
+pub async fn browser_from_id(_id: Option<i32>, _language: Option<&String>, _client_id: Option<&String>, _role_id: Option<&String>, _user_id: Option<&String>) -> Result<Browser, String> {
+	if _id.is_none() || _id.map(|id| id <= 0).unwrap_or(false) {
+		return Err(Error::new(ErrorKind::InvalidData.into(), "Browser Identifier is Mandatory").to_string());
+	}
     let mut _document = Browser::from_id(_id);
-    let _index_name = get_index_name(_language, _client_id, _role_id, _user_id).await.expect("Error getting index");
-    log::info!("Index to search {:}", _index_name);
+
+	let _index_name = match get_index_name(_language, _client_id, _role_id, _user_id).await {
+		Ok(index_name) => index_name,
+		Err(error) => {
+			log::error!("Index name error: {:?}", error.to_string());
+			return Err(error.to_string())
+		}
+	};
+	log::info!("Index to search {:}", _index_name);
+
     _document.index_value = Some(_index_name);
     let _browser_document: &dyn IndexDocument = &_document;
     match get_by_id(_browser_document).await {
@@ -284,7 +295,7 @@ pub async fn browser_from_id(_language: Option<&String>, _client_id: Option<&Str
             )
         },
         Err(error) => {
-            log::warn!("{}", error);
+			log::error!("{}", error);
             Err(error)
         },
     }
@@ -330,15 +341,15 @@ async fn get_index_name(_language: Option<&String>, _client_id: Option<&String>,
 							log::info!("Find with client index `{:}`", _client_index);
 							Ok(_client_index)
 						},
-                        Err(_) => {
-							log::info!("No client index `{:}`", _client_index);
+						Err(_) => {
+							log::warn!("No client index `{:}`", _client_index);
 							match exists_index(_language_index.to_owned()).await {
 								Ok(_) => {
 									log::info!("Find with language index `{:}`", _language_index);
 									Ok(_language_index)
 								},
-                                Err(_) => {
-									log::info!("No language index `{:}`. Find with default index `{:}`.", _language_index, _default_index);
+								Err(_) => {
+									log::warn!("No language index `{:}`. Find with default index `{:}`.", _language_index, _default_index);
                                     Ok(_default_index)
                                 }
                             }
@@ -356,8 +367,15 @@ pub async fn browsers(_language: Option<&String>, _client_id: Option<&String>, _
         None => "".to_owned()
     };
 
-    let _index_name = get_index_name(_language, _client_id, _role_id, _user_id).await.expect("Error getting index");
-    log::info!("Index to search {:}", _index_name);
+	//  Find index
+	let _index_name = match get_index_name(_language, _client_id, _role_id, _user_id).await {
+		Ok(index_name) => index_name,
+		Err(error) => {
+			log::error!("Index name error: {:?}", error.to_string());
+			return Err(Error::new(ErrorKind::InvalidData.into(), error))
+		}
+	};
+	log::info!("Index to search {:}", _index_name);
 
     let mut _document = Browser::default();
     _document.index_value = Some(_index_name);
@@ -375,5 +393,4 @@ pub async fn browsers(_language: Option<&String>, _client_id: Option<&String>, _
         },
         Err(error) => Err(Error::new(ErrorKind::InvalidData.into(), error))
     }
-    // Ok(BrowserResponse::default())
 }

--- a/src/models/window.rs
+++ b/src/models/window.rs
@@ -276,10 +276,21 @@ pub struct Table {
     pub selection_colums: Option<Vec<String>>,
 }
 
-pub async fn window_from_id(_language: Option<&String>, _client_id: Option<&String>, _role_id: Option<&String>, _user_id: Option<&String>, _id: Option<i32>) -> Result<Window, String> {
+pub async fn window_from_id(_id: Option<i32>, _language: Option<&String>, _client_id: Option<&String>, _role_id: Option<&String>, _user_id: Option<&String>) -> Result<Window, String> {
+	if _id.is_none() || _id.map(|id| id <= 0).unwrap_or(false) {
+		return Err(Error::new(ErrorKind::InvalidData.into(), "Window Identifier is Mandatory").to_string());
+	}
     let mut _document = Window::from_id(_id);
-    let _index_name = get_index_name(_language, _client_id, _role_id, _user_id).await.expect("Error getting index");
-    log::info!("Index to search {:}", _index_name);
+
+	let _index_name = match get_index_name(_language, _client_id, _role_id, _user_id).await {
+		Ok(index_name) => index_name,
+		Err(error) => {
+			log::error!("Index name error to {:?}: {:?}", _id.to_owned(), error.to_string());
+			return Err(error.to_string())
+		}
+	};
+	log::info!("Index to search {:}", _index_name);
+
     _document.index_value = Some(_index_name);
     let _window_document: &dyn IndexDocument = &_document;
     match get_by_id(_window_document).await {
@@ -292,7 +303,7 @@ pub async fn window_from_id(_language: Option<&String>, _client_id: Option<&Stri
             Ok(window)
         },
         Err(error) => {
-            log::warn!("{}", error);
+			log::error!("{}", error);
             Err(error)
         },
     }
@@ -338,15 +349,15 @@ async fn get_index_name(_language: Option<&String>, _client_id: Option<&String>,
 							log::info!("Find with client index `{:}`", _client_index);
 							Ok(_client_index)
 						},
-                        Err(_) => {
-							log::info!("No client index `{:}`", _client_index);
+						Err(_) => {
+							log::warn!("No client index `{:}`", _client_index);
 							match exists_index(_language_index.to_owned()).await {
 								Ok(_) => {
 									log::info!("Find with language index `{:}`", _language_index);
 									Ok(_language_index)
 								},
-                                Err(_) => {
-									log::info!("No language index `{:}`. Find with default index `{:}`.", _language_index, _default_index);
+								Err(_) => {
+									log::warn!("No language index `{:}`. Find with default index `{:}`.", _language_index, _default_index);
                                     Ok(_default_index)
                                 }
                             }
@@ -363,9 +374,17 @@ pub async fn windows(_language: Option<&String>, _client_id: Option<&String>, _r
         Some(value) => value.clone(),
         None => "".to_owned()
     };
-    //  Find index
-    let _index_name = get_index_name(_language, _client_id, _role_id, _user_id).await.expect("Error getting index");
-    log::info!("Index to search {:}", _index_name);
+
+	//  Find index
+	let _index_name = match get_index_name(_language, _client_id, _role_id, _user_id).await {
+		Ok(index_name) => index_name,
+		Err(error) => {
+			log::error!("Index name error: {:?}", error.to_string());
+			return Err(Error::new(ErrorKind::InvalidData.into(), error))
+		}
+	};
+	log::info!("Index to search {:}", _index_name);
+
     let mut _document = Window::default();
     _document.index_value = Some(_index_name);
     let _window_document: &dyn IndexDocument = &_document;
@@ -382,5 +401,4 @@ pub async fn windows(_language: Option<&String>, _client_id: Option<&String>, _r
         },
         Err(error) => Err(Error::new(ErrorKind::InvalidData.into(), error))
     }
-    // Ok(WindowResponse::default())
 }


### PR DESCRIPTION
When the url query is missing some mandatory parameter in the frontend you get a 502 error (bad gatweay) but that is very ambiguous because it does not tell the user what was the error or why it was caused.

In this case the example is missing the mandatory `rol_id` parameter, also the error is now answered with the status code in addition to the message.

### Before this changes
![imagen](https://github.com/adempiere/dictionary_rs/assets/20288327/a65431d9-940f-44a1-b0d6-8dfe9c678339)

#### After this changes
![imagen](https://github.com/adempiere/dictionary_rs/assets/20288327/c528ea68-d6ab-4b25-9698-db3f5720b845)

#### Additional context

fixes https://github.com/solop-develop/frontend-core/issues/2278