### PR TITLE
fix: Sort documents on backend.

### DIFF
--- a/src/models/browser.rs
+++ b/src/models/browser.rs
@@ -287,12 +287,15 @@ pub async fn browser_from_id(_id: Option<i32>, _language: Option<&String>, _clie
     let _browser_document: &dyn IndexDocument = &_document;
     match get_by_id(_browser_document).await {
         Ok(value) => {
-            let browser: Browser = serde_json::from_value(value).unwrap();
+			let mut browser: Browser = serde_json::from_value(value).unwrap();
             log::info!("Finded Value: {:?}", browser.id);
-            // Ok(BrowserResponse {
-            //     browser: Some(browser)
-            // })
-            Ok( 
+
+			// sort fields by sequence
+			if let Some(ref mut fields) = browser.fields {
+				fields.sort_by_key(|field| field.sequence.clone().unwrap_or(0));
+			}
+
+            Ok(
                 browser
             )
         },
@@ -375,7 +378,11 @@ pub async fn browsers(_language: Option<&String>, _client_id: Option<&String>, _
         Ok(values) => {
             let mut browsers_list: Vec<Browser> = vec![];
             for value in values {
-                let browser: Browser = serde_json::from_value(value).unwrap();
+				let mut browser: Browser = serde_json::from_value(value).unwrap();
+				// sort fields by sequence
+				if let Some(ref mut fields) = browser.fields {
+					fields.sort_by_key(|field| field.sequence.clone().unwrap_or(0));
+				}
                 browsers_list.push(browser.to_owned());
             }
             Ok(BrowserListResponse {

--- a/src/models/menu.rs
+++ b/src/models/menu.rs
@@ -210,11 +210,14 @@ pub async fn menu_from_id(_id: Option<i32>, _language: Option<&String>, _client_
     let _menu_document: &dyn IndexDocument = &_document;
     match get_by_id(_menu_document).await {
         Ok(value) => {
-            let menu: Menu = serde_json::from_value(value).unwrap();
+			let mut menu: Menu = serde_json::from_value(value).unwrap();
             log::info!("Finded Value: {:?}", menu.id);
-            // Ok(MenuResponse {
-            //     menu: Some(menu)
-            // })
+
+			// sort menu children nodes by sequence
+			if let Some(ref mut children) = menu.children {
+				children.sort_by_key(|child| child.sequence.clone().unwrap_or(0));
+			}
+
             Ok(
                 menu
             )
@@ -302,9 +305,17 @@ pub async fn menus(
         Ok(values) => {
             let mut menus_list: Vec<Menu> = vec![];
             for value in values {
-                let menu: Menu = serde_json::from_value(value).unwrap();
+				let mut menu: Menu = serde_json::from_value(value).unwrap();
+				// sort menu children nodes by sequence
+				if let Some(ref mut children) = menu.children {
+					children.sort_by_key(|child| child.sequence.clone().unwrap_or(0));
+				}
                 menus_list.push(menu.to_owned());
             }
+
+			// sort root menu nodes by sequence
+			menus_list.sort_by_key(|menu| menu.sequence.clone().unwrap_or(0));
+
             Ok(MenuListResponse {
                 menus: Some(menus_list)
             })

--- a/src/models/process.rs
+++ b/src/models/process.rs
@@ -255,11 +255,14 @@ pub async fn process_from_id(_id: Option<i32>, _language: Option<&String>, _clie
     let _process_document: &dyn IndexDocument = &_document;
     match get_by_id(_process_document).await {
         Ok(value) => {
-            let process: Process = serde_json::from_value(value).unwrap();
+			let mut process: Process = serde_json::from_value(value).unwrap();
             log::info!("Finded Value: {:?}", process.id);
-            // Ok(ProcessResponse {
-            //     process: Some(process)
-            // })
+
+			// sort process parameter by sequence
+			if let Some(ref mut parameters) = process.parameters {
+				parameters.sort_by_key(|parameter| parameter.sequence.clone().unwrap_or(0));
+			}
+
             Ok(
                 process
             )
@@ -343,9 +346,14 @@ pub async fn processes(_language: Option<&String>, _client_id: Option<&String>, 
         Ok(values) => {
             let mut processes_list: Vec<Process> = vec![];
             for value in values {
-                let process: Process = serde_json::from_value(value).unwrap();
+				let mut process: Process = serde_json::from_value(value).unwrap();
+				// sort process parameter by sequence
+				if let Some(ref mut parameters) = process.parameters {
+					parameters.sort_by_key(|parameter| parameter.sequence.clone().unwrap_or(0));
+				}
                 processes_list.push(process.to_owned());
             }
+
             Ok(ProcessListResponse {
                 processes: Some(processes_list)
             })

--- a/src/models/window.rs
+++ b/src/models/window.rs
@@ -297,11 +297,20 @@ pub async fn window_from_id(_id: Option<i32>, _language: Option<&String>, _clien
     let _window_document: &dyn IndexDocument = &_document;
     match get_by_id(_window_document).await {
         Ok(value) => {
-            let window: Window = serde_json::from_value(value).unwrap();
+			let mut window: Window = serde_json::from_value(value).unwrap();
             log::info!("Finded Value: {:?}", window.id);
-            // Ok(WindowResponse {
-            //     window: Some(window)
-            // })
+
+			// sort tabs by sequence
+			if let Some(ref mut tabs) = window.tabs {
+				tabs.sort_by_key(|tab| tab.sequence.clone().unwrap_or(0));
+				for tab in tabs.iter_mut() {
+					// sort fields by sequence
+					if let Some(ref mut fields) = tab.fields {
+						fields.sort_by_key(|field| field.sequence.clone().unwrap_or(0));
+					}
+				}
+			}
+
             Ok(window)
         },
         Err(error) => {
@@ -383,9 +392,20 @@ pub async fn windows(_language: Option<&String>, _client_id: Option<&String>, _r
         Ok(values) => {
             let mut windows_list: Vec<Window> = vec![];
             for value in values {
-                let window: Window = serde_json::from_value(value).unwrap();
+				let mut window: Window = serde_json::from_value(value).unwrap();
+				// sort tabs by sequence
+				if let Some(ref mut tabs) = window.tabs {
+					tabs.sort_by_key(|tab| tab.sequence.clone().unwrap_or(0));
+					for tab in tabs.iter_mut() {
+						// sort fields by sequence
+						if let Some(ref mut fields) = tab.fields {
+							fields.sort_by_key(|field| field.sequence.clone().unwrap_or(0));
+						}
+					}
+				}
                 windows_list.push(window.to_owned());
             }
+
             Ok(WindowListResponse {
                 windows: Some(windows_list)
             })


### PR DESCRIPTION
currently the order of the menu does not coincide with the established, likewise the order of tabs, fields and other values that are iterable and require specific order. So we add in this change
- Ordering for the root elements of the menu, and its children.
- Ordered for the fields of the intelligent queries.
- Sort order for process parameters.
- Sorted for window tabs.
- Sorted for window tab fields.

In this way the responsibility is delegated to the backend so that the front only presents the information.

![imagen](https://github.com/adempiere/dictionary_rs/assets/20288327/f62cd3f3-6afd-4fb3-bfbb-d9e48037bba5)

#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/2274