### PR TITLE
fix: `form_id` as process associated on tab.

### DIFF
--- a/src/models/window.rs
+++ b/src/models/window.rs
@@ -259,7 +259,7 @@ pub struct Process {
 	//	Linked
 	pub browser_id: Option<i32>,
 	pub browser: Option<DictionaryEntity>,
-	pub from_id: Option<i32>,
+	pub form_id: Option<i32>,
 	pub form: Option<DictionaryEntity>,
 	pub workflow_id: Option<i32>,
 	pub workflow: Option<DictionaryEntity>,


### PR DESCRIPTION


![imagen](https://github.com/adempiere/dictionary_rs/assets/20288327/fce9466a-cbe0-4938-aca7-1f26226720e3)

#### Additional context:
fixes https://github.com/solop-develop/frontend-core/issues/1325