### PR TITLE
feat: Change route hierarchy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,30 +107,31 @@ INFO  [server] Server Address: "0.0.0.0:7878"
         │   ├──[OPTIONS] -> server::get_menu
         │   └──[GET] -> server::get_menu
         └──dictionary
-            ├──browsers/<id>
-            │   ├──[OPTIONS] -> server::get_browsers
-            │   └──[GET] -> server::get_browsers
             ├──browsers
-            │   ├──[OPTIONS] -> server::get_browsers
-            │   └──[GET] -> server::get_browsers
-            ├──forms/<id>
-            │   ├──[OPTIONS] -> server::get_forms
-            │   └──[GET] -> server::get_forms
+            │   ├──[OPTIONS] -> server::options_response
+            │   ├──[GET] -> server::get_browsers
+            │   └──<id>
+            │       ├──[OPTIONS] -> server::options_response
+            │       └──[GET] -> server::get_browsers
             ├──forms
-            │   ├──[OPTIONS] -> server::get_forms
-            │   └──[GET] -> server::get_forms
-            ├──processes/<id>
-            │   ├──[OPTIONS] -> server::get_process
-            │   └──[GET] -> server::get_process
+            │   ├──[OPTIONS] -> server::options_response
+            │   ├──[GET] -> server::get_forms
+            │   └──<id>
+            │       ├──[OPTIONS] -> server::options_response
+            │       └──[GET] -> server::get_forms
             ├──processes
-            │   ├──[OPTIONS] -> server::get_process
-            │   └──[GET] -> server::get_process
-            ├──windows/<id>
-            │   ├──[OPTIONS] -> server::get_windows
-            │   └──[GET] -> server::get_windows
+            │   ├──[OPTIONS] -> server::options_response
+            │   ├──[GET] -> server::get_processes
+            │   └──<id>
+            │       ├──[OPTIONS] -> server::options_response
+            │       └──[GET] -> server::get_processes
             └──windows
-                ├──[OPTIONS] -> server::get_windows
-                └──[GET] -> server::get_windows
+                ├──[OPTIONS] -> server::options_response
+                ├──[GET] -> server::get_windows
+                └──<id>
+                    ├──[OPTIONS] -> server::options_response
+                    └──[GET] -> server::get_windows
+
 INFO  [server] Kafka Consumer is enabled
 INFO  [server] Kafka queue: "0.0.0.0:29092"
 INFO  [server] Topics to Subscribed: ["menu", "browser", "form", "process", "window"]

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -53,58 +53,58 @@ async fn main() {
 						.options(options_response)
                         .get(get_menu)
                 )
-                .push(
-                    // /api/dictionary
-                    Router::with_path("dictionary")
-						.push(
-							// /api/dictionary/browsers/:id
-							Router::with_path("browsers/<id>")
-								.options(options_response)
-								.get(get_browsers)
-						)
+				.push(
+					// /api/dictionary
+			Router::with_path("dictionary")
 						.push(
 							// /api/dictionary/browsers/
 							Router::with_path("browsers")
 								.options(options_response)
 								.get(get_browsers)
-						)
-						.push(
-							// /api/dictionary/forms/:id
-							Router::with_path("forms/<id>")
-								.options(options_response)
-								.get(get_forms)
+								.push(
+									// /api/dictionary/browsers/:id
+									Router::with_path("<id>")
+										.options(options_response)
+										.get(get_browsers)
+								)
 						)
 						.push(
 							// /api/dictionary/forms/
 							Router::with_path("forms")
 								.options(options_response)
 								.get(get_forms)
+								.push(
+									// /api/dictionary/forms/:id
+									Router::with_path("<id>")
+										.options(options_response)
+										.get(get_forms)
+								)
 						)
 						.push(
-                            // /api/dictionary/processes/:id
-                            Router::with_path("processes/<id>")
+						// /api/dictionary/processes
+					Router::with_path("processes")
 								.options(options_response)
-                                .get(get_process)
-                        )
-                        .push(
-                            // /api/dictionary/processes
-                            Router::with_path("processes")
-								.options(options_response)
-                                .get(get_process)
-                        )
-                        .push(
-                            // /api/dictionary/windows/:id
-                            Router::with_path("windows/<id>")
-								.options(options_response)
-                                .get(get_windows)
+								.get(get_processes)
+								.push(
+									// /api/dictionary/processes/:id
+									Router::with_path("<id>")
+										.options(options_response)
+										.get(get_processes)
+								)
                         )
                         .push(
                             // /api/dictionary/windows/
                             Router::with_path("windows")
 								.options(options_response)
                                 .get(get_windows)
-                        )
-                )
+								.push(
+									// /api/dictionary/windows/:id
+									Router::with_path("<id>")
+										.options(options_response)
+										.get(get_windows)
+								)
+						)
+				)
         )
     ;
     log::info!("{:#?}", router);
@@ -227,7 +227,7 @@ async fn get_menu<'a>(_req: &mut Request, _res: &mut Response) {
 }
 
 #[handler]
-async fn get_process<'a>(_req: &mut Request, _res: &mut Response) {
+async fn get_processes<'a>(_req: &mut Request, _res: &mut Response) {
     let _id = _req.param::<i32>("id");
     let _language = _req.queries().get("language");
     let _client_id = _req.queries().get("client_id");


### PR DESCRIPTION
Now the id of the dictionary entity is inside the path of the dictionary entity type. Also the `get_process` method is renamed to `get_processes`.

#### Before this changes
```
    └──api
        ├──security/menus
        │   ├──[OPTIONS] -> server::options_response
        │   └──[GET] -> server::get_menu
        └──dictionary
            ├──browsers/<id>
            │   ├──[OPTIONS] -> server::options_response
            │   └──[GET] -> server::get_browsers
            ├──browsers
            │   ├──[OPTIONS] -> server::options_response
            │   └──[GET] -> server::get_browsers
            ├──forms/<id>
            │   ├──[OPTIONS] -> server::options_response
            │   └──[GET] -> server::get_forms
            ├──forms
            │   ├──[OPTIONS] -> server::options_response
            │   └──[GET] -> server::get_forms
            ├──processes/<id>
            │   ├──[OPTIONS] -> server::options_response
            │   └──[GET] -> server::get_process
            ├──processes
            │   ├──[OPTIONS] -> server::options_response
            │   └──[GET] -> server::get_process
            ├──windows/<id>
            │   ├──[OPTIONS] -> server::options_response
            │   └──[GET] -> server::get_windows
            └──windows
                ├──[OPTIONS] -> server::options_response
                └──[GET] -> server::get_windows
```


#### After this changes
```
    └──api
        ├──security/menus
        │   ├──[OPTIONS] -> server::options_response
        │   └──[GET] -> server::get_menu
        └──dictionary
            ├──browsers
            │   ├──[OPTIONS] -> server::options_response
            │   ├──[GET] -> server::get_browsers
            │   └──<id>
            │       ├──[OPTIONS] -> server::options_response
            │       └──[GET] -> server::get_browsers
            ├──forms
            │   ├──[OPTIONS] -> server::options_response
            │   ├──[GET] -> server::get_forms
            │   └──<id>
            │       ├──[OPTIONS] -> server::options_response
            │       └──[GET] -> server::get_forms
            ├──processes
            │   ├──[OPTIONS] -> server::options_response
            │   ├──[GET] -> server::get_processes
            │   └──<id>
            │       ├──[OPTIONS] -> server::options_response
            │       └──[GET] -> server::get_processes
            └──windows
                ├──[OPTIONS] -> server::options_response
                ├──[GET] -> server::get_windows
                └──<id>
                    ├──[OPTIONS] -> server::options_response
                    └──[GET] -> server::get_windows
```


