### PR TITLE
feat: Add filter record `ColumnName` to Sort Tab.

### DIFF
--- a/src/models/window.rs
+++ b/src/models/window.rs
@@ -85,6 +85,7 @@ pub struct WindowTab {
 	pub is_sort_tab: Option<bool>,
 	pub sort_order_column_name: Option<String>,
 	pub sort_yes_no_column_name: Option<String>,
+	pub filter_column_name: Option<String>,
 	// External info
 	pub context_column_names: Option<Vec<String>>,
 	pub window_id: Option<i32>,


### PR DESCRIPTION
The filter column for the order tabs must be added, currently it is done from the front end, locating the parent tab and taking the column marked as parent to send it and filter the records. It is preferable to add it in the backend as this is not usually changed, improving performance on the frontend side.

#### Additional context
related issue https://github.com/solop-develop/frontend-core/issues/2070
fixes https://github.com/solop-develop/frontend-core/issues/1166
