### PR TITLE
fix: Change mapping identifier from `text` to `keyword`.

### DIFF
--- a/src/models/browser.rs
+++ b/src/models/browser.rs
@@ -41,9 +41,9 @@ pub struct DictionaryEntity {
 
 #[derive(Deserialize, Serialize, Extractible, Debug, Clone)]
 pub struct Browser {
-    pub uuid: Option<String>,
-    pub internal_id: Option<i32>,
-    pub id: Option<String>,
+	pub uuid: Option<String>,
+	pub internal_id: Option<i32>,
+	pub id: Option<String>,
 	pub code: Option<String>,
     pub name: Option<String>,
     pub description: Option<String>,
@@ -88,9 +88,9 @@ pub struct Reference {
 
 #[derive(Deserialize, Serialize, Extractible, Debug, Clone)]
 pub struct BrowserField {
-    pub uuid: Option<String>,
-    pub internal_id: Option<i32>,
-    pub id: Option<String>,
+	pub uuid: Option<String>,
+	pub id: Option<String>,
+	pub internal_id: Option<i32>,
 	pub column_name: Option<String>,
     pub name: Option<String>,
     pub description: Option<String>,
@@ -131,11 +131,11 @@ pub struct BrowserField {
 }
 
 impl Default for Browser {
-    fn default() -> Self {
-        Self { 
-            uuid: None, 
-            internal_id: None,
-            id: None, 
+	fn default() -> Self {
+		Self {
+			uuid: None,
+			id: None,
+			internal_id: None,
 			code: None,
             name: None, 
             description: None, 
@@ -184,13 +184,14 @@ impl Browser {
 }
 
 impl IndexDocument for Browser {
-    fn mapping(self: &Self) -> serde_json::Value {
-        json!({
-            "mappings" : {
-                "properties" : {
-                    "uuid" : { "type" : "text" },
-                    "id" : { "type" : "text" },
-                    "code" : { "type" : "text" },
+	fn mapping(self: &Self) -> serde_json::Value {
+		json!({
+			"mappings" : {
+				"properties" : {
+					"uuid" : { "type" : "keyword" },
+					"id" : { "type" : "keyword" },
+					"internal_id" : { "type" : "integer" },
+					"code" : { "type" : "keyword" },
                     "name" : { "type" : "text" },
                     "description" : { "type" : "text" },
                     "help" : { "type" : "text" }

--- a/src/models/form.rs
+++ b/src/models/form.rs
@@ -32,8 +32,8 @@ impl Default for FormResponse {
 #[derive(Deserialize, Serialize, Extractible, Debug, Clone)]
 pub struct Form {
 	pub uuid: Option<String>,
+	pub id: Option<String>,
 	pub internal_id: Option<i32>,
-    pub id: Option<String>,
 	pub file_name: Option<String>,
 	pub name: Option<String>,
 	pub description: Option<String>,
@@ -51,8 +51,8 @@ impl Default for Form {
 	fn default() -> Self {
 		Self {
 			uuid: None,
-            internal_id: None,
 			id: None,
+			internal_id: None,
 			file_name: None,
 			name: None,
 			description: None,
@@ -81,9 +81,10 @@ impl IndexDocument for Form {
 		json!({
 			"mappings" : {
 				"properties" : {
-					"uuid" : { "type" : "text" },
-					"id" : { "type" : "text" },
-					"file_name" : { "type" : "text" },
+					"uuid" : { "type" : "keyword" },
+					"id" : { "type" : "keyword" },
+					"internal_id" : { "type" : "integer" },
+					"file_name" : { "type" : "keyword" },
 					"name" : { "type" : "text" },
 					"description" : { "type" : "text" },
 					"help" : { "type" : "text" }

--- a/src/models/generic.rs
+++ b/src/models/generic.rs
@@ -32,12 +32,13 @@ impl Default for Generic {
 }
 
 impl IndexDocument for Generic {
-    fn mapping(self: &Self) -> serde_json::Value {
-        json!({
-            "mappings" : {
-                "properties" : {
-                    "uuid" : { "type" : "text" },
-                    "id" : { "type" : "text" },
+	fn mapping(self: &Self) -> serde_json::Value {
+		json!({
+			"mappings" : {
+				"properties" : {
+					"uuid" : { "type" : "keyword" },
+					"id" : { "type" : "keyword" },
+					"internal_id" : { "type" : "integer" },
                     "parent_id" : { "type" : "integer" },
                     "sequence" : { "type" : "integer" },
                     "name" : { "type" : "text" },

--- a/src/models/menu_item.rs
+++ b/src/models/menu_item.rs
@@ -33,9 +33,9 @@ impl Default for MenuItemResponse {
 
 #[derive(Deserialize, Serialize, Extractible, Debug, Clone)]
 pub struct MenuItem {
-    pub uuid: Option<String>,
-    pub internal_id: Option<i32>,
-    pub id: Option<String>,
+	pub uuid: Option<String>,
+	pub id: Option<String>,
+	pub internal_id: Option<i32>,
     pub parent_id: Option<i32>,
     pub sequence: Option<i32>,
     pub name: Option<String>,
@@ -61,11 +61,11 @@ pub struct MenuItem {
 }
 
 impl Default for MenuItem {
-    fn default() -> Self {
-        Self { 
-            uuid: None, 
-            internal_id: None,
-            id: None, 
+	fn default() -> Self {
+		Self {
+			uuid: None,
+			id: None,
+			internal_id: None,
             parent_id: None, 
             sequence: None, 
             name: None, 
@@ -245,12 +245,13 @@ impl MenuItem {
 }
 
 impl IndexDocument for MenuItem {
-    fn mapping(self: &Self) -> serde_json::Value {
-        json!({
-            "mappings" : {
-                "properties" : {
-                    "uuid" : { "type" : "text" },
-                    "id" : { "type" : "text" },
+	fn mapping(self: &Self) -> serde_json::Value {
+		json!({
+			"mappings" : {
+				"properties" : {
+					"uuid" : { "type" : "keyword" },
+					"id" : { "type" : "keyword" },
+					"internal_id" : { "type" : "integer" },
                     "parent_id" : { "type" : "integer" },
                     "sequence" : { "type" : "integer" },
                     "name" : { "type" : "text" },

--- a/src/models/menu_tree.rs
+++ b/src/models/menu_tree.rs
@@ -31,8 +31,9 @@ impl Default for MenuTreeResponse {
 
 #[derive(Deserialize, Serialize, Extractible, Debug, Clone)]
 pub struct MenuTree {
-    pub internal_id: Option<i32>,
-    pub id: Option<String>,
+	pub uuid: Option<String>,
+	pub id: Option<String>,
+	pub internal_id: Option<i32>,
     pub node_id: Option<i32>,
     pub parent_id: Option<i32>,
     pub sequence: Option<i32>,
@@ -47,10 +48,11 @@ pub struct MenuTree {
 }
 
 impl Default for MenuTree {
-    fn default() -> Self {
-        Self { 
-            id: None, 
-            internal_id: None,
+	fn default() -> Self {
+		Self {
+			uuid: None,
+			id: None,
+			internal_id: None,
             node_id: None,
             parent_id: None, 
             sequence: None, 
@@ -75,17 +77,19 @@ impl MenuTree {
 }
 
 impl IndexDocument for MenuTree {
-    fn mapping(self: &Self) -> serde_json::Value {
-        json!({
-            "mappings" : {
-                "properties" : {
-                    "uuid" : { "type" : "text" },
-                    "id" : { "type" : "text" },
-                    "parent_id" : { "type" : "integer" },
-                    "sequence" : { "type" : "integer" }                }
-            }
-        })
-    }
+	fn mapping(self: &Self) -> serde_json::Value {
+		json!({
+			"mappings" : {
+				"properties" : {
+					"uuid" : { "type" : "keyword" },
+					"id" : { "type" : "keyword" },
+					"internal_id" : { "type" : "integer" },
+					"parent_id" : { "type" : "integer" },
+					"sequence" : { "type" : "integer" }
+				}
+			}
+		})
+	}
 
     fn data(self: &Self) -> serde_json::Value {
         json!(self)

--- a/src/models/process.rs
+++ b/src/models/process.rs
@@ -131,11 +131,11 @@ pub struct ProcessParameters {
 }
 
 impl Default for Process {
-    fn default() -> Self {
+	fn default() -> Self {
 		Self {
-            uuid: None, 
-            internal_id: None,
-            id: None, 
+			uuid: None,
+			id: None,
+			internal_id: None,
 			code: None,
             name: None, 
             description: None, 
@@ -177,13 +177,14 @@ impl Process {
 }
 
 impl IndexDocument for Process {
-    fn mapping(self: &Self) -> serde_json::Value {
-        json!({
-            "mappings" : {
-                "properties" : {
-                    "uuid" : { "type" : "text" },
-                    "id" : { "type" : "text" },
-                    "code" : { "type" : "text" },
+	fn mapping(self: &Self) -> serde_json::Value {
+		json!({
+			"mappings" : {
+				"properties" : {
+					"uuid" : { "type" : "keyword" },
+					"id" : { "type" : "keyword" },
+					"internal_id" : { "type" : "integer" },
+					"code" : { "type" : "keyword" },
                     "name" : { "type" : "text" },
                     "description" : { "type" : "text" },
 					"help" : { "type" : "text" },

--- a/src/models/role.rs
+++ b/src/models/role.rs
@@ -33,9 +33,9 @@ impl Default for RoleResponse {
 
 #[derive(Deserialize, Serialize, Extractible, Debug, Clone)]
 pub struct Role {
-    pub internal_id: Option<i32>,
-    pub id: Option<String>,
-    pub uuid: Option<String>,
+	pub uuid: Option<String>,
+	pub id: Option<String>,
+	pub internal_id: Option<i32>,
     pub name: Option<String>,
     pub description: Option<String>,
     pub tree_id: Option<i32>,
@@ -56,11 +56,11 @@ pub struct Role {
 }
 
 impl Default for Role {
-    fn default() -> Self {
-        Self { 
-            id: None,
-            internal_id: None,
-            uuid: None, 
+	fn default() -> Self {
+		Self {
+			uuid: None,
+			id: None,
+			internal_id: None,
             name: None, 
             description: None, 
             tree_id: None, 
@@ -91,12 +91,13 @@ impl Role {
 }
 
 impl IndexDocument for Role {
-    fn mapping(self: &Self) -> serde_json::Value {
-        json!({
-            "mappings" : {
-                "properties" : {
-                    "uuid" : { "type" : "text" },
-                    "id" : { "type" : "text" },
+	fn mapping(self: &Self) -> serde_json::Value {
+		json!({
+			"mappings" : {
+				"properties" : {
+					"uuid" : { "type" : "keyword" },
+					"id" : { "type" : "keyword" },
+					"internal_id" : { "type" : "integer" },
                     "tree_id" : { "type" : "integer" },
                     "name" : { "type" : "text" },
                     "description" : { "type" : "text" }

--- a/src/models/window.rs
+++ b/src/models/window.rs
@@ -114,9 +114,9 @@ pub struct Reference {
 
 #[derive(Deserialize, Serialize, Extractible, Debug, Clone)]
 pub struct WindowField {
-    pub uuid: Option<String>,
-    pub internal_id: Option<i32>,
-    pub id: Option<String>,
+	pub uuid: Option<String>,
+	pub id: Option<String>,
+	pub internal_id: Option<i32>,
     pub name: Option<String>,
     pub description: Option<String>,
     pub help: Option<String>,
@@ -169,11 +169,11 @@ pub struct WindowField {
 }
 
 impl Default for Window {
-    fn default() -> Self {
-        Self { 
-            uuid: None, 
-            id: None, 
-            internal_id: None,
+	fn default() -> Self {
+		Self {
+			uuid: None,
+			id: None,
+			internal_id: None,
             name: None, 
             description: None, 
             help: None, 
@@ -199,12 +199,13 @@ impl Window {
 }
 
 impl IndexDocument for Window {
-    fn mapping(self: &Self) -> serde_json::Value {
-        json!({
-            "mappings" : {
-                "properties" : {
-                    "uuid" : { "type" : "text" },
-                    "id" : { "type" : "text" },
+	fn mapping(self: &Self) -> serde_json::Value {
+		json!({
+			"mappings" : {
+				"properties" : {
+					"uuid" : { "type" : "keyword" },
+					"id" : { "type" : "keyword" },
+					"internal_id" : { "type" : "integer" },
                     "name" : { "type" : "text" },
                     "description" : { "type" : "text" },
                     "help" : { "type" : "text" }


### PR DESCRIPTION
- `Text` is to match as text parts, and `keyword` to exact complete text.
- Add `internal_id` to mapping document.