### PR TITLE
fix: When `UUID` is null stop thread process.

### DIFF
--- a/src/models/browser.rs
+++ b/src/models/browser.rs
@@ -288,9 +288,9 @@ pub async fn browser_from_id(_id: Option<String>, _language: Option<&String>, _d
 			Error::new(ErrorKind::InvalidData.into(), "Browser Identifier is Mandatory").to_string()
 		);
 	}
-    let mut _document = Browser::from_id(_id);
+	let mut _document: Browser = Browser::from_id(_id);
 
-	let _index_name = match get_index_name("browser".to_string(),_language, _dictionary_code).await {
+	let _index_name: String = match get_index_name("browser".to_string(),_language, _dictionary_code).await {
 		Ok(index_name) => index_name,
 		Err(error) => {
 			log::error!("Index name error: {:?}", error.to_string());
@@ -329,7 +329,7 @@ pub async fn browsers(_language: Option<&String>, _search_value: Option<&String>
     };
 
 	//  Find index
-	let _index_name = match get_index_name("browser".to_string(), _language, _dictionary_code).await {
+	let _index_name: String = match get_index_name("browser".to_string(), _language, _dictionary_code).await {
 		Ok(index_name) => index_name,
 		Err(error) => {
 			log::error!("Index name error: {:?}", error.to_string());
@@ -338,7 +338,7 @@ pub async fn browsers(_language: Option<&String>, _search_value: Option<&String>
 	};
 	log::info!("Index to search {:}", _index_name);
 
-    let mut _document = Browser::default();
+	let mut _document: Browser = Browser::default();
     _document.index_value = Some(_index_name);
     let _browser_document: &dyn IndexDocument = &_document;
     match find(_browser_document, _search_value, 0, 10).await {

--- a/src/models/browser.rs
+++ b/src/models/browser.rs
@@ -181,6 +181,10 @@ impl Browser {
         browser.id = _id;
         browser
     }
+
+	pub fn to_string(&self) -> String {
+		format!("Browser: UUID {:?}, ID {:?}, Name {:?}, Index: {:?}", self.uuid, self.internal_id, self.name, self.index_value)
+	}
 }
 
 impl IndexDocument for Browser {
@@ -204,9 +208,12 @@ impl IndexDocument for Browser {
         json!(self)
     }
 
-    fn id(self: &Self) -> String {
-        self.id.to_owned().unwrap()
-    }
+	fn id(self: &Self) -> String {
+		self.id.to_owned().unwrap_or_else(|| {
+			log::error!("{}", self.to_string());
+			"".to_string()
+		})
+	}
 
     fn index_name(self: &Self) -> String {
         match &self.index_value {

--- a/src/models/form.rs
+++ b/src/models/form.rs
@@ -74,6 +74,10 @@ impl Form {
 		form.id = _id;
 		form
 	}
+
+	pub fn to_string(&self) -> String {
+		format!("Form: UUID {:?}, ID {:?}, Name {:?}, Index: {:?}", self.uuid, self.internal_id, self.name, self.index_value)
+	}
 }
 
 impl IndexDocument for Form {
@@ -98,7 +102,10 @@ impl IndexDocument for Form {
 	}
 
 	fn id(self: &Self) -> String {
-		self.id.to_owned().unwrap()
+		self.id.to_owned().unwrap_or_else(|| {
+			log::error!("{}", self.to_string());
+			"".to_string()
+		})
 	}
 
 	fn index_name(self: &Self) -> String {

--- a/src/models/form.rs
+++ b/src/models/form.rs
@@ -136,9 +136,9 @@ pub async fn form_from_id(_id: Option<String>, _language: Option<&String>, _dict
 			Error::new(ErrorKind::InvalidData.into(), "Form Identifier is Mandatory").to_string()
 		);
 	}
-	let mut _document = Form::from_id(_id);
+	let mut _document: Form = Form::from_id(_id);
 
-	let _index_name = match get_index_name("form".to_string(), _language, _dictionary_code).await {
+	let _index_name: String = match get_index_name("form".to_string(), _language, _dictionary_code).await {
 		Ok(index_name) => index_name,
 		Err(error) => {
 			log::error!("Index name error: {:?}", error.to_string());
@@ -152,7 +152,7 @@ pub async fn form_from_id(_id: Option<String>, _language: Option<&String>, _dict
 	match get_by_id(_form_document).await {
 		Ok(value) => {
 			let form: Form = serde_json::from_value(value).unwrap();
-			log::info!("Finded Value: {:?}", form.id);
+			log::info!("Finded Form Value: {:?}", form.id);
 			// Ok(FormResponse {
 			// 	form: Some(form)
 			// })
@@ -174,7 +174,7 @@ pub async fn forms(_language: Option<&String>, _search_value: Option<&String>, _
 	};
 
 	//  Find index
-	let _index_name = match get_index_name("form".to_string(),_language, _dictionary_code).await {
+	let _index_name: String = match get_index_name("form".to_string(),_language, _dictionary_code).await {
 		Ok(index_name) => index_name,
 		Err(error) => {
 			log::error!("Index name error: {:?}", error.to_string());
@@ -183,7 +183,7 @@ pub async fn forms(_language: Option<&String>, _search_value: Option<&String>, _
 	};
 	log::info!("Index to search {:}", _index_name);
 
-	let mut _document = Form::default();
+	let mut _document: Form = Form::default();
 	_document.index_value = Some(_index_name);
 	let _forms_document: &dyn IndexDocument = &_document;
 	match find(_forms_document, _search_value, 0, 10).await {

--- a/src/models/menu_item.rs
+++ b/src/models/menu_item.rs
@@ -242,6 +242,10 @@ impl MenuItem {
 			}
 		})
     }
+
+	pub fn to_string(&self) -> String {
+		format!("Menu Item: UUID {:?}, ID {:?}, Name {:?}, Index: {:?}", self.uuid, self.internal_id, self.name, self.index_value)
+	}
 }
 
 impl IndexDocument for MenuItem {
@@ -267,9 +271,12 @@ impl IndexDocument for MenuItem {
         json!(self)
     }
 
-    fn id(self: &Self) -> String {
-        self.id.to_owned().unwrap()
-    }
+	fn id(self: &Self) -> String {
+		self.id.to_owned().unwrap_or_else(|| {
+			log::error!("{}", self.to_string());
+			"".to_string()
+		})
+	}
 
     fn index_name(self: &Self) -> String {
         match &self.index_value {

--- a/src/models/menu_tree.rs
+++ b/src/models/menu_tree.rs
@@ -134,9 +134,9 @@ pub async fn menu_tree_from_id(_id: Option<String>, _dictionary_code: Option<&St
 			Error::new(ErrorKind::InvalidData.into(), "MenuTree Identifier is Mandatory")
 		);
 	}
-    let mut _document = MenuTree::from_id(_id);
+	let mut _document: MenuTree = MenuTree::from_id(_id);
 
-	let mut _index_name = "menu_tree".to_string();
+	let mut _index_name: String = "menu_tree".to_string();
 	if let Some(code) = _dictionary_code {
 		if !code.trim().is_empty() {
 			_index_name.push_str("_");
@@ -150,7 +150,7 @@ pub async fn menu_tree_from_id(_id: Option<String>, _dictionary_code: Option<&St
     match get_by_id(_menu_document).await {
         Ok(value) => {
 			let mut menu: MenuTree = serde_json::from_value(value).unwrap();
-            log::info!("Finded Value: {:?}", menu.id);
+			log::info!("Finded Menu Tree Value: {:?}", menu.id);
 			// sort menu children nodes by sequence
 			if let Some(ref mut children) = menu.children {
 				children.sort_by_key(|child| child.sequence.clone().unwrap_or(0));

--- a/src/models/menu_tree.rs
+++ b/src/models/menu_tree.rs
@@ -74,6 +74,10 @@ impl MenuTree {
         menu.id = _id;
         menu
     }
+
+	pub fn to_string(&self) -> String {
+		format!("Menu Tree: UUID {:?}, ID {:?}, Index: {:?}", self.uuid, self.internal_id, self.index_value)
+	}
 }
 
 impl IndexDocument for MenuTree {
@@ -95,9 +99,12 @@ impl IndexDocument for MenuTree {
         json!(self)
     }
 
-    fn id(self: &Self) -> String {
-        self.id.to_owned().unwrap()
-    }
+	fn id(self: &Self) -> String {
+		self.id.to_owned().unwrap_or_else(|| {
+			log::error!("{}", self.to_string());
+			"".to_string()
+		})
+	}
 
     fn index_name(self: &Self) -> String {
         match &self.index_value {

--- a/src/models/process.rs
+++ b/src/models/process.rs
@@ -176,6 +176,10 @@ impl Process {
         process.id = _id;
         process
     }
+
+	pub fn to_string(&self) -> String {
+		format!("Process/Report: UUID {:?}, ID {:?}, Name {:?}, Index: {:?}", self.uuid, self.internal_id, self.name, self.index_value)
+	}
 }
 
 impl IndexDocument for Process {
@@ -200,9 +204,12 @@ impl IndexDocument for Process {
         json!(self)
     }
 
-    fn id(self: &Self) -> String {
-        self.id.to_owned().unwrap()
-    }
+	fn id(self: &Self) -> String {
+		self.id.to_owned().unwrap_or_else(|| {
+			log::error!("{}", self.to_string());
+			"".to_string()
+		})
+	}
 
     fn index_name(self: &Self) -> String {
         match &self.index_value {

--- a/src/models/process.rs
+++ b/src/models/process.rs
@@ -269,9 +269,9 @@ pub async fn process_from_id(_id: Option<String>, _language: Option<&String>, _d
 			Error::new(ErrorKind::InvalidData.into(), "Process/Report Identifier is Mandatory").to_string()
 		);
 	}
-    let mut _document = Process::from_id(_id);
+	let mut _document: Process = Process::from_id(_id);
 
-	let _index_name = match get_index_name("process".to_string(), _language, _dictionary_code).await {
+	let _index_name: String = match get_index_name("process".to_string(), _language, _dictionary_code).await {
 		Ok(index_name) => index_name,
 		Err(error) => {
 			log::error!("Index name error: {:?}", error.to_string());
@@ -285,7 +285,7 @@ pub async fn process_from_id(_id: Option<String>, _language: Option<&String>, _d
     match get_by_id(_process_document).await {
         Ok(value) => {
 			let mut process: Process = serde_json::from_value(value).unwrap();
-            log::info!("Finded Value: {:?}", process.id);
+			log::info!("Finded Process Value: {:?}", process.id);
 
 			// sort process parameter by sequence
 			if let Some(ref mut parameters) = process.parameters {
@@ -310,7 +310,7 @@ pub async fn processes(_language: Option<&String>, _search_value: Option<&String
     };
 
 	//  Find index
-	let _index_name = match get_index_name("process".to_string(), _language, _dictionary_code).await {
+	let _index_name: String = match get_index_name("process".to_string(), _language, _dictionary_code).await {
 		Ok(index_name) => index_name,
 		Err(error) => {
 			log::error!("Index name error: {:?}", error.to_string());
@@ -319,7 +319,7 @@ pub async fn processes(_language: Option<&String>, _search_value: Option<&String
 	};
 	log::info!("Index to search {:}", _index_name);
 
-    let mut _document = Process::default();
+	let mut _document: Process = Process::default();
     _document.index_value = Some(_index_name);
     let _process_document: &dyn IndexDocument = &_document;
     match find(_process_document, _search_value, 0, 10).await {

--- a/src/models/role.rs
+++ b/src/models/role.rs
@@ -164,10 +164,17 @@ pub async fn role_from_id(_uuid: Option<&String>, _client_uuid: Option<&String>,
     let _role_document: &dyn IndexDocument = &_document;
     match get_by_id(_role_document).await {
         Ok(value) => {
-			let role: Role = serde_json::from_value(value).unwrap();
-            log::info!("Finded Value: {:?}", role.id);
-            Ok(role)
-        },
+			match serde_json::from_value::<Role>(value) {
+				Ok(role) => {
+					log::info!("Finded Role Value: {:?}", role.id);
+					Ok(role)
+				},
+				Err(error) => {
+					log::error!("{}", error);
+					Err(error.to_string())
+				},
+			}
+		},
         Err(error) => {
 			log::error!("{}", error);
             Err(error)

--- a/src/models/role.rs
+++ b/src/models/role.rs
@@ -88,6 +88,10 @@ impl Role {
         menu.uuid = _id.cloned();
         menu
     }
+
+	pub fn to_string(&self) -> String {
+		format!("Form: UUID {:?}, ID {:?}, Name {:?}, Index: {:?}", self.uuid, self.internal_id, self.name, self.index_value)
+	}
 }
 
 impl IndexDocument for Role {
@@ -110,9 +114,12 @@ impl IndexDocument for Role {
         json!(self)
     }
 
-    fn id(self: &Self) -> String {
-        self.uuid.to_owned().unwrap()
-    }
+	fn id(self: &Self) -> String {
+		self.id.to_owned().unwrap_or_else(|| {
+			log::error!("{}", self.to_string());
+			"".to_string()
+		})
+	}
 
     fn index_name(self: &Self) -> String {
         match &self.index_value {

--- a/src/models/window.rs
+++ b/src/models/window.rs
@@ -196,6 +196,10 @@ impl Window {
         window.id = _id;
         window
     }
+
+	pub fn to_string(&self) -> String {
+		format!("Window: UUID {:?}, ID {:?}, Name {:?}, Index: {:?}", self.uuid, self.internal_id, self.name, self.index_value)
+	}
 }
 
 impl IndexDocument for Window {
@@ -218,9 +222,12 @@ impl IndexDocument for Window {
         json!(self)
     }
 
-    fn id(self: &Self) -> String {
-        self.id.to_owned().unwrap()
-    }
+	fn id(self: &Self) -> String {
+		self.id.to_owned().unwrap_or_else(|| {
+			log::error!("{}", self.to_string());
+			"".to_string()
+		})
+	}
 
     fn index_name(self: &Self) -> String {
         match &self.index_value {

--- a/src/models/window.rs
+++ b/src/models/window.rs
@@ -298,9 +298,9 @@ pub async fn window_from_id(_id: Option<String>, _language: Option<&String>, _di
 			Error::new(ErrorKind::InvalidData.into(), "Window Identifier is Mandatory").to_string()
 		);
 	}
-    let mut _document = Window::from_id(_id.to_owned());
+	let mut _document: Window = Window::from_id(_id.to_owned());
 
-	let _index_name = match get_index_name("window".to_string(), _language,_dictionary_code).await {
+	let _index_name: String = match get_index_name("window".to_string(), _language,_dictionary_code).await {
 		Ok(index_name) => index_name,
 		Err(error) => {
 			log::error!("Index name error to {:?}: {:?}", _id.to_owned(), error.to_string());
@@ -314,7 +314,7 @@ pub async fn window_from_id(_id: Option<String>, _language: Option<&String>, _di
     match get_by_id(_window_document).await {
         Ok(value) => {
 			let mut window: Window = serde_json::from_value(value).unwrap();
-            log::info!("Finded Value: {:?}", window.id);
+			log::info!("Finded Window Value: {:?}", window.id);
 
 			// sort tabs by sequence
 			if let Some(ref mut tabs) = window.tabs {
@@ -343,7 +343,7 @@ pub async fn windows(_language: Option<&String>, _search_value: Option<&String>,
     };
 
 	//  Find index
-	let _index_name = match get_index_name("window".to_string(), _language, _dictionary_code).await {
+	let _index_name: String = match get_index_name("window".to_string(), _language, _dictionary_code).await {
 		Ok(index_name) => index_name,
 		Err(error) => {
 			log::error!("Index name error: {:?}", error.to_string());
@@ -352,7 +352,7 @@ pub async fn windows(_language: Option<&String>, _search_value: Option<&String>,
 	};
 	log::info!("Index to search {:}", _index_name);
 
-    let mut _document = Window::default();
+	let mut _document: Window = Window::default();
     _document.index_value = Some(_index_name);
     let _window_document: &dyn IndexDocument = &_document;
     match find(_window_document, _search_value, 0, 10).await {


### PR DESCRIPTION
### Before this changes
```
2024-09-30T20:14:48.382351531Z 2024-09-30T20:14:48.382Z WARN  [server] Topic: "role", invalid type: null, expected a string at line 1 column 88
2024-09-30T20:14:48.389843074Z thread 'tokio-runtime-worker' panicked at src/models/role.rs:114:30:
2024-09-30T20:14:48.389891386Z called `Option::unwrap()` on a `None` value
2024-09-30T20:14:48.389895003Z note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

### After this changes
![imagen](https://github.com/user-attachments/assets/42cab041-94af-42a0-bbfb-94857585700a)


![image_2024-09-30_18-08-58](https://github.com/user-attachments/assets/ed6847e2-6843-4aed-a0d3-4681c55c3307)

### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/2715
