### PR TITLE
feat: Update OpenSearch to `2.3.0` version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ log = "0.4.21"
 simple_logger = "5.0.0"
 futures = "0.3.30"
 rdkafka = "0.36.2"
-opensearch = "2.2.0"
+opensearch = "2.3.0"
 
 [[bin]]
 name = "server"


### PR DESCRIPTION
See changelog https://github.com/opensearch-project/opensearch-rs/releases/tag/v2.3.0