### PR TITLE
feat: Overwrite display type on reference to `Button` fields.

### DIFF
--- a/src/models/browser.rs
+++ b/src/models/browser.rs
@@ -83,6 +83,9 @@ pub struct Browser {
 
 #[derive(Deserialize, Serialize, Extractible, Debug, Clone)]
 pub struct Reference {
+	pub table_name: Option<String>,
+	pub reference_id: Option<i32>,
+	pub reference_value_id: Option<i32>,
 	pub context_column_names: Option<Vec<String>>
 }
 

--- a/src/models/process.rs
+++ b/src/models/process.rs
@@ -95,6 +95,9 @@ pub struct Process {
 
 #[derive(Deserialize, Serialize, Extractible, Debug, Clone)]
 pub struct Reference {
+	pub table_name: Option<String>,
+	pub reference_id: Option<i32>,
+	pub reference_value_id: Option<i32>,
 	pub context_column_names: Option<Vec<String>>
 }
 

--- a/src/models/window.rs
+++ b/src/models/window.rs
@@ -109,6 +109,9 @@ pub struct DependendField {
 
 #[derive(Deserialize, Serialize, Extractible, Debug, Clone)]
 pub struct Reference {
+	pub table_name: Option<String>,
+	pub reference_id: Option<i32>,
+	pub reference_value_id: Option<i32>,
 	pub context_column_names: Option<Vec<String>>
 }
 


### PR DESCRIPTION
If there is a button that has a reference value, for the case of search or smart query criteria you can overwrite the display type to a drop-down list.

### Before this changes
https://github.com/user-attachments/assets/ee012247-5f77-4d58-9f03-33fd05e34bf0

### After this changes
![imagen](https://github.com/user-attachments/assets/9f9564d4-f46b-4227-9ffe-c4c7798e5c5e)


### Addional context
fixes https://github.com/solop-develop/frontend-core/issues/2795
