### PR TITLE
feat: Improve warning menu.

### DIFF
--- a/src/models/menu.rs
+++ b/src/models/menu.rs
@@ -140,9 +140,18 @@ pub async fn allowed_menu(_language: Option<&String>, _client_id: Option<&String
         Err(error) => return Err(Error::new(ErrorKind::InvalidData.into(), error))
     };
 
-    if _role.tree_id.is_none() {
-        return Err(Error::new(ErrorKind::InvalidData.into(), "Tree ID not found"))
-    }
+	if _role.tree_id.is_none() {
+		log::error!("Tree ID not found, on role {:?} = {:?}", _role.name, _role.internal_id);
+		return Err(
+			Error::new(ErrorKind::InvalidData.into(), "Tree ID not found")
+		)
+	}
+	if _role.tree_uuid.is_none() {
+		log::error!("Tree UUID not found, on role {:?} = {:?}", _role.name, _role.internal_id);
+		return Err(
+			Error::new(ErrorKind::InvalidData.into(), "Tree UUID not found")
+		)
+	}
 
 	let _tree_result: Result<MenuTree, Error> = menu_tree_from_id(_role.tree_uuid, _dictionary_code).await;
 	let _tree: MenuTree = match _tree_result {

--- a/src/models/menu_tree.rs
+++ b/src/models/menu_tree.rs
@@ -152,7 +152,7 @@ pub async fn menu_tree_from_id(_id: Option<String>, _dictionary_code: Option<&St
     match get_by_id(_menu_document).await {
         Ok(value) => {
 			let mut menu: MenuTree = serde_json::from_value(value).unwrap();
-			log::info!("Finded Menu Tree Value: {:?}", menu.id);
+			log::info!("Finded Menu `{:?}` Tree Value: {:?}", menu.name, menu.id);
 			// sort menu children nodes by sequence
 			if let Some(ref mut children) = menu.children {
 				children.sort_by_key(|child: &MenuTree| child.sequence.clone().unwrap_or(0));


### PR DESCRIPTION
When a menu tree does not have an ID or UUID, an error will be printed in the log indicating the name of the tree in order to obtain more precise information.