### PR TITLE
fix: Load without keyword to `action_uuid`.

### DIFF
--- a/src/models/menu_item.rs
+++ b/src/models/menu_item.rs
@@ -181,7 +181,7 @@ impl MenuItem {
 									},
 									{
 										"terms": {
-											"action_uuid.keyword": _window_access
+											"action_uuid": _window_access
 										}
 									}
 								]
@@ -197,7 +197,7 @@ impl MenuItem {
 									},
 									{
 										"terms": {
-											"action_uuid.keyword": _form_access
+											"action_uuid": _form_access
 										}
 									}
 								]
@@ -213,7 +213,7 @@ impl MenuItem {
 									},
 									{
 										"terms": {
-											"action_uuid.keyword": _browser_access
+											"action_uuid": _browser_access
 										}
 									}
 								]
@@ -229,7 +229,7 @@ impl MenuItem {
 									},
 									{
 										"terms": {
-											"action_uuid.keyword": _process_access
+											"action_uuid": _process_access
 										}
 									}
 								]
@@ -245,7 +245,7 @@ impl MenuItem {
 									},
 									{
 										"terms": {
-											"action_uuid.keyword": _process_access
+											"action_uuid": _process_access
 										}
 									}
 								]
@@ -261,7 +261,7 @@ impl MenuItem {
 									},
 									{
 										"terms": {
-											"action_uuid.keyword": _workflow_access
+											"action_uuid": _workflow_access
 										}
 									}
 								]


### PR DESCRIPTION
Solves https://github.com/adempiere/dictionary_rs/issues/88
No load menu after build with docker.
