### PR TITLE
fix: Load without keyword to `action` field in OpenSearch query

### DIFF
--- a/src/models/menu_item.rs
+++ b/src/models/menu_item.rs
@@ -176,7 +176,7 @@ impl MenuItem {
 								"must": [
 									{
 										"term": {
-											"action.keyword": "W"
+											"action": "W"
 										}
 									},
 									{
@@ -192,7 +192,7 @@ impl MenuItem {
 								"must": [
 									{
 										"term": {
-											"action.keyword": "X"
+											"action": "X"
 										}
 									},
 									{
@@ -208,7 +208,7 @@ impl MenuItem {
 								"must": [
 									{
 										"term": {
-											"action.keyword": "S"
+											"action": "S"
 										}
 									},
 									{
@@ -224,7 +224,7 @@ impl MenuItem {
 								"must": [
 									{
 										"term": {
-											"action.keyword": "P"
+											"action": "P"
 										}
 									},
 									{
@@ -240,7 +240,7 @@ impl MenuItem {
 								"must": [
 									{
 										"term": {
-											"action.keyword": "R"
+											"action": "R"
 										}
 									},
 									{
@@ -256,7 +256,7 @@ impl MenuItem {
 								"must": [
 									{
 										"term": {
-											"action.keyword": "F"
+											"action": "F"
 										}
 									},
 									{


### PR DESCRIPTION
The `action` field in OpenSearch is mapped as `keyword` type, which means
  it does not have a `.keyword` sub-field. Using `action.keyword` in term
  queries returns 0 results, causing the menu to show only summary items.

  This follows the same fix applied to `action_uuid` in #86.
